### PR TITLE
Possible regex fix for emotes with inequality symbols

### DIFF
--- a/src/util/Utils.java
+++ b/src/util/Utils.java
@@ -493,7 +493,9 @@ public class Utils {
                     for (int i = 0; i < emotes.length(); i++) {
                         JSONObject emote = emotes.getJSONObject(i);
                         JSONObject imageStuff = emote.getJSONArray("images").getJSONObject(0);//3 is URL, 4 is height
-                        String regex = emote.getString("regex").replaceAll("&lt\\\\;", "<").replaceAll("&gt\\\\;", ">");
+                        String regex = emote.getString("regex")
+                            .replaceAll("\\\\&lt\\\\;", "\\<")
+                            .replaceAll("\\\\&gt\\\\;", "\\>");
                         if (imageStuff != null) {//split("-")[4] is the filename
                             String uRL = imageStuff.getString("url");
                             set.add(new StringArray(new String[]{regex, uRL, (uRL.split("-")[4] + ".png")}));


### PR DESCRIPTION
Twitch performs HTML escaping on the symbols first, turning "<" and ">" into "&lt;" and "&gt;".
All symbols are then escaped for JavaScript's regex syntax: "&gt\;" and "&lt\;".
We then have to add another layer of escaping for Java's own regex (for replaceAll): "\&gt\;" and "\&lt\;".
Finally, last layer of escaping for Java's string literals: "\\&gt\\;" and "\\&lt\\;".

The replacement strings also need escaping (once for regex, and once more for Java string literals), since "<" and ">" characters have special meaning in Java regex (as part of lookbehind construct). So they become "\<" and "\>".

Partially fixes #37 
