### PR TITLE
Fixed recognition of Twitch emotes.

### DIFF
--- a/src/util/Utils.java
+++ b/src/util/Utils.java
@@ -789,7 +789,10 @@ public class Utils {
                     break;
                 }
                 if (!tf.isEnabled()) break;
-                regex = "\\b" + regex + "\\b";
+                if (!regex.matches("^\\W.*|.*\\W$")) {
+                    //boundary checks are only necessary for emotes that start and end with a word character.
+                    regex = "\\b" + regex + "\\b";
+                }
                 Pattern p = Pattern.compile(regex);
                 Matcher m = p.matcher(message);
                 while (m.find() && !GUIMain.shutDown) {


### PR DESCRIPTION
Fixes #37. There were several problems with the old code:
1) "\b" in a Java string literal is an escape character for "backspace." Use "\\b" for RegEx word boundaries.
2) "\\b" already matches line-beginning and line-end positions, so extra checks against "^" and "$" were not necessary.
3) Twitch chat only does boundary checks for emotes that do not start or end with a symbol. Emotes like "<3", ":D", etc, can appear in any part of the string. Moreover, "\\b" does not match the place where these symbols start/end because they are not "words" from regex perspective -- that's why these emotes did not get recognized at all, except when on a line by itself.

All of these issues have been fixed.
