### PR TITLE
Auto-scrolling after Timeout

### DIFF
--- a/src/main/java/gui/ChatPane.java
+++ b/src/main/java/gui/ChatPane.java
@@ -214,6 +214,8 @@ public class ChatPane implements DocumentListener {
         JScrollBar scrollBar = scrollPane.getVerticalScrollBar();
         boolean scrollBarAtBottom = isScrollBarFullyExtended(scrollBar);
         if (scrollBarAtBottom) {
+            // We're back at the bottom, reset timer
+            scrollbarTimestamp = -1;
             scrollToBottom();
         } else if(scrollbarTimestamp != -1){
             if(System.currentTimeMillis() - scrollbarTimestamp >= 10 * 1000L) {

--- a/src/main/java/gui/ChatPane.java
+++ b/src/main/java/gui/ChatPane.java
@@ -36,6 +36,10 @@ public class ChatPane implements DocumentListener {
 
     private JFrame poppedOutPane = null;
 
+    // The timestamp of when we decided to wait to scroll back down
+    private long scrollbarTimestamp = -1;
+
+
     public void setPoppedOutPane(JFrame pane) {
         poppedOutPane = pane;
     }
@@ -201,11 +205,25 @@ public class ChatPane implements DocumentListener {
         maybeScrollToBottom();
     }
 
+    /**
+     * Used to queue a scrollToBottom only if the scroll bar is already at the bottom
+     * OR
+     * It's been more than 10 seconds since we've been scrolled up and have been receiving messages
+     */
     private void maybeScrollToBottom() {
         JScrollBar scrollBar = scrollPane.getVerticalScrollBar();
         boolean scrollBarAtBottom = isScrollBarFullyExtended(scrollBar);
         if (scrollBarAtBottom) {
             scrollToBottom();
+        } else if(scrollbarTimestamp != -1){
+            if(System.currentTimeMillis() - scrollbarTimestamp >= 10 * 1000L) {
+                // If the time difference is more than 10 seconds, scroll to bottom anyway after resetting time
+                scrollbarTimestamp = -1;
+                GUIMain.log("Scrolled from timeout..");
+                scrollToBottom();
+            }
+        } else {
+            scrollbarTimestamp = System.currentTimeMillis();
         }
     }
 


### PR DESCRIPTION
I implemented auto-scrolling without the need for an additional thread or listener. Since we only really care about scrolling back down if we're receiving messages, we only want to scroll down to the bottom after 10 seconds while receiving messages. So when we check if we should `maybeScrollDown` and decide we're not at the bottom, we start the timeout. Then, every time we do that same check:
 - If we're at the bottom, reset the "timer"
 - If we're still not at the bottom, check the timer. If difference >= 10s, reset and scroll to bottom
 - If timer doesn't exist, initialize it to current time

There are drawbacks to this, because it required people to be chatting (or some other calls to `maybeScrollToBottom`), but this is a case that will not appear often and also matter. If no one is chatting, there's no need to scroll down anyway. The benefits of not adding another thread or listener outweigh these drawbacks.

