### PR TITLE
!volume, logging and small bug fixes

### DIFF
--- a/src/main/java/face/FaceManager.java
+++ b/src/main/java/face/FaceManager.java
@@ -113,7 +113,7 @@ public class FaceManager {
                         break;
                     }
                 } catch (Exception e) {
-                    GUIMain.log(e.getMessage());
+                    GUIMain.log(e);
                 }
             }
         }
@@ -137,7 +137,7 @@ public class FaceManager {
                 return getSubIcon(channel);
             }
         } catch (Exception e) {
-            GUIMain.log(e.getMessage());
+            GUIMain.log(e);
         }
         return null;
     }
@@ -169,7 +169,7 @@ public class FaceManager {
                 }
             }
         } catch (Exception e) {
-            GUIMain.log(e.getMessage());
+            GUIMain.log(e);
         }
     }
 
@@ -421,7 +421,7 @@ public class FaceManager {
         try {
             StyleConstants.setIcon(set, sizeIcon(new File(face).toURI().toURL()));
         } catch (Exception e) {
-            GUIMain.log(e.getMessage());
+            GUIMain.log(e);
         }
     }
 
@@ -471,7 +471,8 @@ public class FaceManager {
                 return newFace;
             }
         } catch (Exception e) {
-            GUIMain.log("Failed to download emote ID " + emote + " due to exception " + e.getMessage());
+            GUIMain.log("Failed to download emote ID " + emote + " due to exception: ");
+            GUIMain.log(e);
         }
         return null;
     }
@@ -489,7 +490,8 @@ public class FaceManager {
                 toReturn = new FrankerFaceZ(Utils.removeExt(fileName), toSave.getAbsolutePath(), true);
             }
         } catch (Exception e) {
-            GUIMain.log("Failed to download FFZ Faces due to Exception: " + e.getMessage());
+            GUIMain.log("Failed to download FFZ Faces due to Exception: ");
+            GUIMain.log(e);
         }
         return toReturn;
     }
@@ -564,8 +566,7 @@ public class FaceManager {
                 return ImageIO.write(image, "PNG", toSave);//save it
             }
         } catch (Exception e) {
-            if (!e.getMessage().contains("Unsupported"))
-                GUIMain.log(e.getMessage());
+            GUIMain.log(e);
         }
         return false;
     }

--- a/src/main/java/gui/ChatPane.java
+++ b/src/main/java/gui/ChatPane.java
@@ -403,7 +403,7 @@ public class ChatPane implements DocumentListener {
             if (shouldPulse())
                 GUIMain.instance.pulseTab(this);
         } catch (Exception e) {
-            GUIMain.log(e.getMessage());
+            GUIMain.log(e);
         }
     }
 
@@ -475,7 +475,7 @@ public class ChatPane implements DocumentListener {
             try {
                 textPane.getStyledDocument().insertString(textPane.getStyledDocument().getLength(), string, set);
             } catch (Exception e) {
-                GUIMain.log(e.getMessage());
+                GUIMain.log(e);
             }
         };
         wrapper.addPrint(r);
@@ -499,7 +499,7 @@ public class ChatPane implements DocumentListener {
                 insertIcon(m, status, (status == IconEnum.SUBSCRIBER ? message.getChannel() : null));
             }
         } catch (Exception e) {
-            GUIMain.log(e.getMessage());
+            GUIMain.log(e);
         }
         boolean shouldIncrement = ((status == IconEnum.SUBSCRIBER) && (m.getLocal().getExtra() == null));//checking for repeat messages
         if (shouldIncrement) subCount++;
@@ -522,7 +522,8 @@ public class ChatPane implements DocumentListener {
             print(m, " ", null);
             print(m, icon.getType().type, attrs);
         } catch (Exception e) {
-            GUIMain.log("INSERT ICON " + e.getMessage());
+            GUIMain.log("INSERT ICON: ");
+            GUIMain.log(e);
         }
     }
 
@@ -554,7 +555,8 @@ public class ChatPane implements DocumentListener {
                 doc.remove(0, start);
                 resetCleanupCounter();
             } catch (Exception e) {
-                GUIMain.log("Failed clearing chat: " + e.getMessage());
+                GUIMain.log("Failed clearing chat: ");
+                GUIMain.log(e);
             }
         }
         messageOut = false;

--- a/src/main/java/gui/GUIMain.java
+++ b/src/main/java/gui/GUIMain.java
@@ -30,6 +30,8 @@ import java.awt.event.ComponentAdapter;
 import java.awt.event.ComponentEvent;
 import java.awt.event.WindowAdapter;
 import java.awt.event.WindowEvent;
+import java.io.PrintWriter;
+import java.io.StringWriter;
 import java.util.ArrayList;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CopyOnWriteArraySet;
@@ -186,8 +188,20 @@ public class GUIMain extends JFrame {
      * @param message The message to log.
      */
     public static void log(Object message) {
-        if (message != null && GUIMain.chatPanes != null && !GUIMain.chatPanes.isEmpty())
-            MessageQueue.addMessage(new Message(message.toString(), Message.MessageType.LOG_MESSAGE));
+        String toPrint;
+        Message.MessageType type = Message.MessageType.LOG_MESSAGE; // Moved here to allow for changing message type to something like error for throwables
+        if(message instanceof Throwable) {
+            Throwable t = (Throwable)message;
+            StringWriter sw = new StringWriter();
+            PrintWriter pw = new PrintWriter(sw);
+            t.printStackTrace(pw);
+            toPrint = sw.toString(); // stack trace as a string
+        } else {
+            // Not a throwable.. Darn strings
+            toPrint = message.toString();
+        }
+        if (toPrint != null && GUIMain.chatPanes != null && !GUIMain.chatPanes.isEmpty())
+            MessageQueue.addMessage(new Message(toPrint, type));
     }
 
     public static void updateTitle(String viewerCount) {

--- a/src/main/java/gui/GUISettings.java
+++ b/src/main/java/gui/GUISettings.java
@@ -123,7 +123,7 @@ public class GUISettings extends JFrame {
                 GUIMain.currentSettings.staffIcon = GUISettings.class.getResource("/image/staff.png");
             }
         } catch (Exception e) {
-            GUIMain.log(e.getMessage());
+            GUIMain.log(e);
         }
 
         //sounds
@@ -200,7 +200,7 @@ public class GUISettings extends JFrame {
                     }
 
                 } catch (Exception e) {
-                    GUIMain.log(e.getMessage());
+                    GUIMain.log(e);
                 }
             }
         }
@@ -381,7 +381,7 @@ public class GUISettings extends JFrame {
             icon.getImage().flush();
             label.setIcon(icon);
         } catch (Exception e) {
-            GUIMain.log(e.getMessage());
+            GUIMain.log(e);
         }
     }
 

--- a/src/main/java/gui/GUISettings.java
+++ b/src/main/java/gui/GUISettings.java
@@ -1492,6 +1492,8 @@ public class GUISettings extends JFrame {
             if (!Utils.checkText(commandField.getText()).equals("")) {
                 if (filePaths.length > 0) {
                     String command = commandField.getText();
+                    if(command.startsWith("!"))
+                        command = command.substring(1);
                     //update the tree
                     DefaultTreeModel model = (DefaultTreeModel) soundTree.getModel();
                     DefaultMutableTreeNode root = (DefaultMutableTreeNode) model.getRoot();

--- a/src/main/java/gui/GUIUpdate.java
+++ b/src/main/java/gui/GUIUpdate.java
@@ -43,7 +43,7 @@ public class GUIUpdate extends JFrame {
             text = stanSB.toString();
             return true;
         } catch (Exception e) {
-            GUIMain.log(e.getMessage());
+            GUIMain.log(e);
         }
         return false;
     }

--- a/src/main/java/gui/TokenListener.java
+++ b/src/main/java/gui/TokenListener.java
@@ -41,7 +41,7 @@ public class TokenListener extends Thread {
                     break;
                 }
             } catch (Exception e) {
-                GUIMain.log(e.getMessage());
+                GUIMain.log(e);
             }
         }
     }

--- a/src/main/java/irc/IRCBot.java
+++ b/src/main/java/irc/IRCBot.java
@@ -449,6 +449,19 @@ public class IRCBot extends MessageHandler {
                         case SEE_OR_SET_REPLY_TYPE:
                             commandResponse = parseReplyType(first, botnakUserName);
                             break;
+                        case SEE_OR_SET_VOLUME:
+                            if (first == null || first.equals("")) {
+                                getBot().sendMessage(channel, "Volume is " + String.format("%.1f", GUIMain.currentSettings.soundVolumeGain));
+                            } else {
+                                Float volume = Float.parseFloat(first);
+                                if (volume > 100F)
+                                    volume = 100F;
+                                else if (volume < 0F)
+                                    volume = 0F;
+                                GUIMain.currentSettings.soundVolumeGain = volume;
+                                getBot().sendMessage(channel, "Volume set to " + String.format("%.1f", GUIMain.currentSettings.soundVolumeGain));
+                            }
+                            break;
                         default:
                             break;
 

--- a/src/main/java/irc/message/MessageQueue.java
+++ b/src/main/java/irc/message/MessageQueue.java
@@ -78,7 +78,7 @@ public class MessageQueue extends Thread {
                     }
                     addToQueue(wrap);
                 } catch (Exception e) {
-                    GUIMain.log(e.getMessage());
+                    GUIMain.log(e);
                 }
             });
         }

--- a/src/main/java/irc/message/MessageWrapper.java
+++ b/src/main/java/irc/message/MessageWrapper.java
@@ -34,7 +34,7 @@ public class MessageWrapper {
                 try {
                     prints.forEach(java.lang.Runnable::run);
                 } catch (Exception e) {
-                    GUIMain.log(e.getMessage());
+                    GUIMain.log(e);
                 }
             };
             if (EventQueue.isDispatchThread()) {
@@ -43,7 +43,7 @@ public class MessageWrapper {
                 try {
                     EventQueue.invokeLater(handler);
                 } catch (Exception e) {
-                    GUIMain.log(e.getMessage());
+                    GUIMain.log(e);
                 }
             }
         }

--- a/src/main/java/lib/pircbot/org/jibble/pircbot/PircBot.java
+++ b/src/main/java/lib/pircbot/org/jibble/pircbot/PircBot.java
@@ -113,7 +113,7 @@ public class PircBot {
             socketIn = socket.getInputStream();
             socketOut = socket.getOutputStream();
         } catch (Exception e) {
-            GUIMain.log(e.getMessage());
+            GUIMain.log(e);
             return false;
         }
 

--- a/src/main/java/sound/SoundEntry.java
+++ b/src/main/java/sound/SoundEntry.java
@@ -1,5 +1,7 @@
 package sound;
 
+import gui.GUIMain;
+
 import javax.sound.sampled.*;
 import java.io.Closeable;
 import java.io.File;
@@ -102,6 +104,19 @@ public class SoundEntry implements Closeable {
         } else {
             this.clip.setFramePosition(0);
         }
+        FloatControl volume = (FloatControl) this.clip.getControl(FloatControl.Type.MASTER_GAIN);
+        /** @author Chrisazy
+         * I've decided that -75.0 is what qualifies as silent, so that's our baseline
+         * We need to counter the logarithmic nature of gain, so we use Pow with base 10
+         * We use it on 100 - volume setting because we're actually considering 0 gain to be 100%
+         *      and -75.0 gain to be 0%
+         * We subtract by 1 because we want Math.Pow(10,(100-100)) to be 0, instead of 1.
+         * Lastly, we normalize our gain by multiplying by our "silent" level divided by the actual 0% level
+         *      (Since without the normalization at 0% we get a gain of -9, that's out 0% level)
+         * Shit's so cash.
+         */
+        float vol = -(float) ((75F / 9F) * (Math.pow(10, ((100 - GUIMain.currentSettings.soundVolumeGain) / 100)) - 1));
+        volume.setValue(vol);
         this.clip.start();
         //sepl.incrementAndGet(); TODO counter
     }

--- a/src/main/java/util/APIRequests.java
+++ b/src/main/java/util/APIRequests.java
@@ -134,7 +134,7 @@ public class APIRequests {
                     }
                 }
             } catch (Exception e) {
-                GUIMain.log(e.getMessage());
+                GUIMain.log(e);
             }
             return toRet;
         }
@@ -262,11 +262,11 @@ public class APIRequests {
                     int response = c.getResponseCode();
                     toReturn = (response == 204);
                 } catch (Exception e) {
-                    GUIMain.log(e.getMessage());
+                    GUIMain.log(e);
                 }
                 c.disconnect();
             } catch (Exception e) {
-                GUIMain.log(e.getMessage());
+                GUIMain.log(e);
             }
             return toReturn;
         }

--- a/src/main/java/util/Utils.java
+++ b/src/main/java/util/Utils.java
@@ -241,7 +241,7 @@ public class Utils {
             }
             out.close();
         } catch (IOException e) {
-            GUIMain.log(e.getMessage());
+            GUIMain.log(e);
         }
     }
 
@@ -863,7 +863,7 @@ public class Utils {
             Pattern.compile(toCheck);
             return true;
         } catch (Exception e) {
-            GUIMain.log(e.getMessage());
+            GUIMain.log(e);
             return false;
         }
     }
@@ -893,7 +893,8 @@ public class Utils {
             }
             toRead.close();
         } catch (Exception e) {
-            GUIMain.log("Failed to read buffered reader due to exception: " + e.getMessage());
+            GUIMain.log("Failed to read buffered reader due to exception: ");
+            GUIMain.log(e);
         }
     }
 }

--- a/src/main/java/util/comm/ConsoleCommand.java
+++ b/src/main/java/util/comm/ConsoleCommand.java
@@ -64,7 +64,8 @@ public class ConsoleCommand {
         SHOW_UPTIME,
         SEE_PREV_SOUND_SUB,
         SEE_PREV_SOUND_DON,
-        SEE_OR_SET_REPLY_TYPE
+        SEE_OR_SET_REPLY_TYPE,
+        SEE_OR_SET_VOLUME
     }
 
     /**

--- a/src/main/java/util/settings/Settings.java
+++ b/src/main/java/util/settings/Settings.java
@@ -110,6 +110,7 @@ public class Settings {
     //Graphite = "lib.jtattoo.com.jtattoo.plaf.graphite.GraphiteLookAndFeel"
 
     public String date;
+    public float soundVolumeGain = 100;
 
     public Settings() {//default account
         modIcon = Settings.class.getResource("/image/mod.png");
@@ -748,6 +749,7 @@ public class Settings {
         hardcoded.add(new ConsoleCommand("lastsubsound", ConsoleCommand.Action.SEE_PREV_SOUND_SUB, Constants.PERMISSION_ALL, null));
         hardcoded.add(new ConsoleCommand("lastdonationsound", ConsoleCommand.Action.SEE_PREV_SOUND_DON, Constants.PERMISSION_ALL, null));
         hardcoded.add(new ConsoleCommand("botreply", ConsoleCommand.Action.SEE_OR_SET_REPLY_TYPE, Constants.PERMISSION_DEV, null));
+        hardcoded.add(new ConsoleCommand("volume", ConsoleCommand.Action.SEE_OR_SET_VOLUME, Constants.PERMISSION_MOD, null));
 
         if (Utils.areFilesGood(ccommandsFile.getAbsolutePath())) {
             try (BufferedReader br = new BufferedReader(new InputStreamReader(ccommandsFile.toURI().toURL().openStream()))) {

--- a/src/main/java/util/settings/Settings.java
+++ b/src/main/java/util/settings/Settings.java
@@ -282,7 +282,7 @@ public class Settings {
                     accountManager.addTask(new Task(null, Task.Type.CREATE_BOT_ACCOUNT, null));
                 }
             } catch (Exception e) {
-                GUIMain.log(e.getMessage());
+                GUIMain.log(e);
             }
         }
         if (type == 1) {//defaults
@@ -300,25 +300,25 @@ public class Settings {
                 try {
                     modIcon = new URL(p.getProperty("CustomMod", modIcon.toString()));
                 } catch (Exception e) {
-                    GUIMain.log(e.getMessage());
+                    GUIMain.log(e);
                 }
                 useBroad = Boolean.parseBoolean(p.getProperty("UseBroad", "false"));
                 try {
                     broadIcon = new URL(p.getProperty("CustomBroad", broadIcon.toString()));
                 } catch (Exception e) {
-                    GUIMain.log(e.getMessage());
+                    GUIMain.log(e);
                 }
                 useAdmin = Boolean.parseBoolean(p.getProperty("UseAdmin", "false"));
                 try {
                     adminIcon = new URL(p.getProperty("CustomAdmin", adminIcon.toString()));
                 } catch (Exception e) {
-                    GUIMain.log(e.getMessage());
+                    GUIMain.log(e);
                 }
                 useStaff = Boolean.parseBoolean(p.getProperty("UseStaff", "false"));
                 try {
                     staffIcon = new URL(p.getProperty("CustomStaff", staffIcon.toString()));
                 } catch (Exception e) {
-                    GUIMain.log(e.getMessage());
+                    GUIMain.log(e);
                 }
                 cleanupChat = Boolean.parseBoolean(p.getProperty("ClearChat", "true"));
                 logChat = Boolean.parseBoolean(p.getProperty("LogChat", "false"));
@@ -332,7 +332,7 @@ public class Settings {
                 botReplyType = Integer.parseInt(p.getProperty("BotReplyType", "0"));
                 GUIMain.log("Loaded defaults!");
             } catch (Exception e) {
-                GUIMain.log(e.getMessage());
+                GUIMain.log(e);
             }
         }
     }
@@ -357,7 +357,7 @@ public class Settings {
             try {
                 p.store(new FileWriter(accountsFile), "Account Info");
             } catch (IOException e) {
-                GUIMain.log(e.getMessage());
+                GUIMain.log(e);
             }
         }
         if (type == 1) {//deaults data
@@ -390,7 +390,7 @@ public class Settings {
             try {
                 p.store(new FileWriter(defaultsFile), "Default Settings");
             } catch (IOException e) {
-                GUIMain.log(e.getMessage());
+                GUIMain.log(e);
             }
         }
     }
@@ -416,7 +416,7 @@ public class Settings {
             }
             GUIMain.log("Loaded sounds!");
         } catch (Exception e) {
-            GUIMain.log(e.getMessage());
+            GUIMain.log(e);
         }
     }
 
@@ -436,7 +436,7 @@ public class Settings {
                 br.println(sb.toString());
             });
         } catch (Exception e) {
-            GUIMain.log(e.getMessage());
+            GUIMain.log(e);
         }
     }
 
@@ -460,7 +460,7 @@ public class Settings {
                 toReturn = true;
             }
         } catch (Exception e) {
-            GUIMain.log(e.getMessage());
+            GUIMain.log(e);
         }
         return toReturn;
     }
@@ -481,7 +481,7 @@ public class Settings {
                 Collections.shuffle(SoundEngine.getEngine().getDonationStack());
             }
         } catch (Exception e) {
-            GUIMain.log(e.getMessage());
+            GUIMain.log(e);
         }
     }
 
@@ -498,7 +498,7 @@ public class Settings {
             }
             GUIMain.log("Loaded user colors!");
         } catch (Exception e) {
-            GUIMain.log(e.getMessage());
+            GUIMain.log(e);
         }
     }
 
@@ -511,7 +511,7 @@ public class Settings {
                             GUIMain.userColMap.get(s).getGreen() + "," +
                             GUIMain.userColMap.get(s).getBlue()));
         } catch (Exception e) {
-            GUIMain.log(e.getMessage());
+            GUIMain.log(e);
         }
     }
 
@@ -528,7 +528,7 @@ public class Settings {
                 br.println(s + "," + fa.getRegex() + "," + fa.getFilePath());
             });
         } catch (Exception e) {
-            GUIMain.log(e.getMessage());
+            GUIMain.log(e);
         }
     }
 
@@ -547,7 +547,7 @@ public class Settings {
             FaceManager.doneWithFaces = true;
             GUIMain.log("Loaded custom faces!");
         } catch (Exception e) {
-            GUIMain.log(e.getMessage());
+            GUIMain.log(e);
         }
     }
 
@@ -562,7 +562,7 @@ public class Settings {
                         br.println(s + "," + fa.getRegex() + "," + Boolean.toString(fa.isEnabled()));
                     });
         } catch (Exception e) {
-            GUIMain.log(e.getMessage());
+            GUIMain.log(e);
         }
     }
 
@@ -581,11 +581,11 @@ public class Settings {
                             Boolean.parseBoolean(split[2]));
                     FaceManager.twitchFaceMap.put(emoteID, tf);
                 } catch (Exception e) {
-                    GUIMain.log(e.getMessage());
+                    GUIMain.log(e);
                 }
             }
         } catch (Exception e) {
-            GUIMain.log(e.getMessage());
+            GUIMain.log(e);
         }
     }
 
@@ -636,7 +636,7 @@ public class Settings {
             }
             GUIMain.log("Loaded text commands!");
         } catch (Exception e) {
-            GUIMain.log(e.getMessage());
+            GUIMain.log(e);
         }
     }
 
@@ -663,7 +663,7 @@ public class Settings {
                 }
             }
         } catch (Exception e) {
-            GUIMain.log(e.getMessage());
+            GUIMain.log(e);
         }
     }
 
@@ -690,7 +690,7 @@ public class Settings {
                 }
             }
         } catch (Exception e) {
-            GUIMain.log(e.getMessage());
+            GUIMain.log(e);
         }
     }
 
@@ -785,7 +785,7 @@ public class Settings {
                     }
                 }
             } catch (Exception e) {
-                GUIMain.log(e.getMessage());
+                GUIMain.log(e);
             }
         } else { //first time boot/reset/deleted file etc.
             GUIMain.conCommands.addAll(hardcoded.stream().collect(Collectors.toList()));
@@ -822,7 +822,7 @@ public class Settings {
                     GUIMain.keywordMap.put(split[0], new Color(r, g, b));
                 }
             } catch (Exception e) {
-                GUIMain.log(e.getMessage());
+                GUIMain.log(e);
             }
         } else {
             if (accountManager.getUserAccount() != null) {
@@ -840,7 +840,7 @@ public class Settings {
                 br.println(word + "," + c.getRed() + "," + c.getGreen() + "," + c.getBlue());
             });
         } catch (Exception e) {
-            GUIMain.log(e.getMessage());
+            GUIMain.log(e);
         }
     }
 
@@ -851,7 +851,7 @@ public class Settings {
         try (PrintWriter br = new PrintWriter(subIconsFile)) {
             FaceManager.subIconSet.stream().forEach(i -> br.println(i.getChannel() + "," + i.getFileLoc()));
         } catch (Exception e) {
-            GUIMain.log(e.getMessage());
+            GUIMain.log(e);
         }
     }
 
@@ -864,7 +864,7 @@ public class Settings {
             }
             GUIMain.log("Loaded subscriber icons!");
         } catch (Exception e) {
-            GUIMain.log(e.getMessage());
+            GUIMain.log(e);
         }
     }
 
@@ -886,7 +886,7 @@ public class Settings {
             }
             GUIMain.log("Loaded donors!");
         } catch (Exception e) {
-            GUIMain.log(e.getMessage());
+            GUIMain.log(e);
         }
     }
 
@@ -895,7 +895,7 @@ public class Settings {
         try (PrintWriter br = new PrintWriter(donatorsFile)) {
             donationManager.getDonors().stream().forEach(d -> br.println(d.getName() + "," + d.getDonated()));
         } catch (Exception e) {
-            GUIMain.log(e.getMessage());
+            GUIMain.log(e);
         }
     }
 
@@ -910,7 +910,7 @@ public class Settings {
                     br.println(d.getDonationID() + "[" + d.getFromWho() + "[" + d.getNote() + "["
                             + d.getAmount() + "[" + Instant.ofEpochMilli(d.getDateReceived().getTime()).toString()));
         } catch (Exception e) {
-            GUIMain.log(e.getMessage());
+            GUIMain.log(e);
         }
     }
 
@@ -944,7 +944,7 @@ public class Settings {
                 GUIMain.log("Loaded donations!");
             }
         } catch (Exception e) {
-            GUIMain.log(e.getMessage());
+            GUIMain.log(e);
         }
     }
 
@@ -962,7 +962,7 @@ public class Settings {
                     s -> br.println(s.getName() + "[" + s.getStarted().toString() + "["
                             + String.valueOf(s.isActive()) + "[" + s.getStreak()));
         } catch (Exception e) {
-            GUIMain.log(e.getMessage());
+            GUIMain.log(e);
         }
     }
 
@@ -984,7 +984,7 @@ public class Settings {
             if (!subscribers.isEmpty()) subscriberManager.fillSubscribers(subscribers);
             GUIMain.log("Loaded subscribers!");
         } catch (Exception e) {
-            GUIMain.log(e.getMessage());
+            GUIMain.log(e);
         }
     }
 
@@ -1036,7 +1036,7 @@ public class Settings {
                 }
             }
         } catch (Exception e) {
-            GUIMain.log(e.getMessage());
+            GUIMain.log(e);
         }
     }
 
@@ -1086,7 +1086,7 @@ public class Settings {
             GUIMain.channelPane.setSelectedIndex(index);
             GUIMain.log("Loaded tabs!");
         } catch (Exception e) {
-            GUIMain.log(e.getMessage());
+            GUIMain.log(e);
         }
     }
 
@@ -1104,7 +1104,7 @@ public class Settings {
             }
             GUIMain.log("Loaded name faces!");
         } catch (Exception e) {
-            GUIMain.log(e.getMessage());
+            GUIMain.log(e);
         }
     }
 
@@ -1132,7 +1132,7 @@ public class Settings {
         try (PrintWriter pr = new PrintWriter(lafFile)) {
             pr.println(lookAndFeel);
         } catch (Exception e) {
-            GUIMain.log(e.getMessage());
+            GUIMain.log(e);
         }
     }
 
@@ -1169,7 +1169,7 @@ public class Settings {
             pr.println("p" + GUIMain.instance.getLocationOnScreen().x + "," + GUIMain.instance.getLocationOnScreen().y);
             pr.println("s" + GUIMain.instance.getSize().getWidth() + "," + GUIMain.instance.getSize().getHeight());
         } catch (Exception e) {
-            GUIMain.log(e.getMessage());
+            GUIMain.log(e);
         }
     }
 }

--- a/src/main/java/util/settings/SubscriberManager.java
+++ b/src/main/java/util/settings/SubscriberManager.java
@@ -226,8 +226,7 @@ public class SubscriberManager {
                 }
             }
         } catch (Exception e) {
-            if (!e.getMessage().contains("oauth_token"))
-                GUIMain.log(e.getMessage());
+            GUIMain.log(e);
         }
     }
 }


### PR DESCRIPTION
I implemented the !volume command in the form `!volume float` where `float` is a float between `0.0` and `100.0` (with error checking of course) If you just type `!volume` then you get the current volume. 

I implemented a check for the logging that checks if the object passed to it is a Throwable (i.e. an Exception) and if it is, will log the stack trace instead. I then implemented this in the FFZ loading to find a bug

When trying to load the API, if you don't have the FFZ SSL certificate in your truststore (which is really really finicky, even if you've been to that site and accepted risks) then you get an exception and fail to load them. Now we ... sorta .. ignore it. It was self-signed, so we can't trust it no matter what, so we just ignore the SSL check all together.

Fixed a "bug" where if you typed the name of a sound command like `!sound` and hit save, the command created was `!!sound`. So now it won't do that.

I replaced all of the places that used `e.getMessage()` for logging by keeping any existing text like `"Blah failed because of exception: "` and doing an additional log of just the exception on the next line. 

I'll probably go through and clean up some of the try-catch blocks to be more explicit on what they're catching and also make sure there aren't other exceptions that aren't being logged, but I'll save that fun for after the new GUI gets pushed.