### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,20 +5,20 @@ Botnak is a Java-based IRC chat client with bot capabilities and a focus on Twit
 
 Botnak 2 Episode 2 has a while to go before being 100% polished and released! You can track its progress in the [Episode 2 Milestone tab](https://github.com/Gocnak/Botnak/milestones).
 
-#Download
+# Download
 The latest (pre-compiled) build can be found in the [releases tab](https://github.com/Gocnak/Botnak/releases).
 
 Keep in mind, this does not mean that Botnak is a final product quite yet. The fact Episode 2 is not completed yet implies there will be multiple changes, some of which may require additional research to have Botnak work completely. It is only recommended to download this if you wish to test Botnak as-is and report bugs.
 
-#Issues
+# Issues
 Speaking of reporting bugs, if you come across an issue, simply open a New Issue in the [issues tab](https://github.com/Gocnak/Botnak/issues/new)! I am using that tab to track progress of Episode 2, so an issue there would be the best place to put it. If you don't wish to publicly report the issue, go ahead and [PM me on twitch](http://www.twitch.tv/message/compose?to=gocnak)!
 
-#Requirements
+# Requirements
 You will need the latest version of Java 8 to run Botnak. [Download it here.](http://www.oracle.com/technetwork/java/javase/downloads/jre8-downloads-2133155.html)
 
 A full example list of commands and such can be found [here](http://bit.ly/1366RwM).
 
-#Credits
+# Credits
 
 [JSON Library](https://github.com/douglascrockford/JSON-java) for making API parsing much easier
 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
